### PR TITLE
[add]#4 使用品入力ダイアログの機能修正

### DIFF
--- a/purchasedItem.go
+++ b/purchasedItem.go
@@ -19,6 +19,7 @@ type Item struct {
 	Quantity          uint16
 	PriceIncludingTax string
 	ItemStatus        string
+	RemainingQuantity uint16
 	UsedRate          string
 	UsedItems         []usedItem
 }
@@ -47,6 +48,7 @@ func (ab *accountBook) getPurchasedItems() ([]*Item, error) {
 			return nil, err
 		}
 
+		i.RemainingQuantity = i.Quantity - usedQuantity
 		i.UsedRate = fmt.Sprintf("%.0f %%", (float64(usedQuantity)/float64(i.Quantity))*100.0)
 		i.UsedItems = uis
 

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -33,7 +33,10 @@ $(function(){
     $(".addUsedItemBtn").click(function(){
         //購入品IDを補足
         PurchaseItemID = $(this).data('id');
-        $('input[name="purchaseItemID"]').val(PurchaseItemID)
+        $('#addUsedItemDialog input[name="purchaseItemID"]').val(PurchaseItemID);
+        //残個数を個数の最大値に設定
+        RemainingQuantity = $(this).data('requantity');
+        $('#addUsedItemDialog input[name="quantity"]').attr("max",RemainingQuantity);
         
         // ダイアログを表示する
         $("#addUsedItemDialog").dialog("open");

--- a/template/index.html
+++ b/template/index.html
@@ -48,7 +48,7 @@
                     <input name="itemName" type="text" required>
                 </div>
                 <div id="quantity">
-                    <label for="quantity">個数*</label>
+                    <label for="quantity">購入数*</label>
                     <br />
                     <input name="quantity" type="number" required>
                 </div>
@@ -85,7 +85,7 @@
                 <th colspan="4">店舗</th>
                 <th>カテゴリー</th>
                 <th>購入品</th>
-                <th>個数</th>
+                <th>購入数</th>
                 <th>金額（税込）</th>
                 <th>ステータス</th>
                 <th class="noBorder"></th>
@@ -122,7 +122,7 @@
                     </button>
                 </td>
                 <td class="noBorder">
-                    <button class="addUsedItemBtn" type="submit" data-id="{{.ID}}" {{- if or (eq .ItemStatus "使用済") (eq .ItemStatus "廃棄")}} disabled="disabled"{{- end}}>
+                    <button class="addUsedItemBtn" type="submit" data-id="{{.ID}}" data-requantity="{{.RemainingQuantity}}" {{- if or (eq .ItemStatus "使用済") (eq .ItemStatus "廃棄")}} disabled="disabled"{{- end}}>
                         入力
                     </button>
                 </td>
@@ -158,8 +158,8 @@
                     <label><input type="radio" name="timing" value="003">夜</label>
                     <label><input type="radio" name="timing" value="004" checked>他</label>
                 </div>
-                <label for="quantity">個数*</label>
-                <input name="quantity" type="number" required>
+                <label for="quantity">使用数*</label>
+                <input name="quantity" type="number" max="0" required>
                 <br />
                 <label for="nemu">メニュー</label>
                 <input name="nemu" type="text">


### PR DESCRIPTION
残数（購入数 - 使用済の数） を超えた数を入力しても送信できないよう修正
合わせて、個数、購入数、使用数と表示がぶれていた部分を統一
close #4